### PR TITLE
Remove duplicate blocks in orchestrator

### DIFF
--- a/data_processing/orchestrators.py
+++ b/data_processing/orchestrators.py
@@ -22,38 +22,20 @@ except ImportError:
     )
 
 # Importaciones relativas para módulos dentro del mismo paquete 'data_processing'
+
 from .loaders import _cargar_y_preparar_datos
 from .aggregators import _agregar_datos_diarios
- c0tc8c-codex/extend-metric_calculators-for-active-days
-from .metric_calculators import _calcular_dias_activos_totales, _calcular_entidades_activas_por_dia
+from .metric_calculators import (
+    _calcular_dias_activos_totales,
+    _calcular_entidades_activas_por_dia,
+)
 from .report_sections import (
     _generar_tabla_vertical_global, _generar_tabla_vertical_entidad,
     _generar_tabla_embudo_rendimiento, _generar_tabla_embudo_bitacora,
     _generar_analisis_ads, _generar_tabla_top_ads_historico,
     _generar_tabla_top_adsets_historico, _generar_tabla_top_campaigns_historico,
-    _generar_tabla_bitacora_entidad
+    _generar_tabla_bitacora_entidad, _generar_tabla_bitacora_detallada,
 )
-from .metric_calculators import _calcular_dias_activos_totales, _calcular_entidades_activas_por_dia
-from .report_sections import (
-    _generar_tabla_vertical_global, _generar_tabla_vertical_entidad,
-    _generar_tabla_embudo_rendimiento, _generar_tabla_embudo_bitacora,
-    _generar_analisis_ads, _generar_tabla_top_ads_historico,
-    _generar_tabla_top_adsets_historico, _generar_tabla_top_campaigns_historico,
-    _generar_tabla_bitacora_entidad
-)
-from .metric_calculators import _calcular_dias_activos_totales, _calcular_entidades_activas_por_dia
-from .report_sections import (
-    _generar_tabla_vertical_global, _generar_tabla_vertical_entidad,
-    _generar_tabla_embudo_rendimiento, _generar_tabla_embudo_bitacora,
-    _generar_analisis_ads, _generar_tabla_top_ads_historico,
-    _generar_tabla_top_adsets_historico, _generar_tabla_top_campaigns_historico,
-    _generar_tabla_bitacora_entidad
-    _generar_tabla_bitacora_entidad,
-    _generar_tabla_bitacora_detallada
-
-)
-main
-
 # Importaciones de módulos en la raíz del proyecto
 from config import numeric_internal_cols
 
@@ -208,7 +190,6 @@ def procesar_reporte_rendimiento(input_files, output_dir, output_filename, statu
             try: _generar_tabla_top_ads_historico(df_daily_agg,active_days_ad,log,detected_currency) 
             except Exception as e_s6: log(f"\n!!! Error Sección 6 (Top Ads): {e_s6} !!!\n{traceback.format_exc()}",importante=True)
 
-c0tc8c-codex/extend-metric_calculators-for-active-days
             log("\n\n============================================================");log("===== Resumen del Proceso =====");log("============================================================")
             if log_summary_messages_orchestrator:
                 for msg in log_summary_messages_orchestrator:
@@ -218,24 +199,6 @@ c0tc8c-codex/extend-metric_calculators-for-active-days
                 log("  No se generaron mensajes de resumen.")
             log("============================================================")
 
-            log("\n\n============================================================");log("===== Resumen del Proceso =====");log("============================================================")
-            if log_summary_messages_orchestrator:
-                for msg in log_summary_messages_orchestrator:
-                    clean_msg = re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','', msg).strip().replace('---','-')
-                    log(f"  - {clean_msg}")
-            else:
-                log("  No se generaron mensajes de resumen.")
-            log("============================================================")
-
-            log("\n\n============================================================");log("===== Resumen del Proceso =====");log("============================================================")
-            if log_summary_messages_orchestrator:
-                for msg in log_summary_messages_orchestrator:
-                    clean_msg = re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','', msg).strip().replace('---','-')
-                    log(f"  - {clean_msg}")
-            else:
-                log("  No se generaron mensajes de resumen.")
-            log("============================================================")
-main
             log("\n\n--- FIN DEL REPORTE RENDIMIENTO ---",importante=True); status_queue.put("---DONE---")
     except Exception as e_main:
         error_details=traceback.format_exc(); log_msg=f"!!! Error Fatal General Reporte Rendimiento: {e_main} !!!\n{error_details}";
@@ -303,9 +266,7 @@ def procesar_reporte_bitacora(input_files, output_dir, output_filename, status_q
 
             log("\n--- Análisis de Bitácora ---")
             log("\n--- Iniciando Agregación Diaria (Bitácora) ---", importante=True)
-c0tc8c-codex/extend-metric_calculators-for-active-days
             df_daily_agg_full = _agregar_datos_diarios(df_combined, status_queue, selected_adsets)
-
             if df_daily_agg_full is None or df_daily_agg_full.empty or 'date' not in df_daily_agg_full.columns or df_daily_agg_full['date'].dropna().empty:
                 log("!!! Falló agregación diaria o no hay fechas válidas. Abortando Bitácora. !!!", importante=True)
                 status_queue.put("---ERROR---"); return
@@ -328,40 +289,7 @@ c0tc8c-codex/extend-metric_calculators-for-active-days
             except Exception as e_det:
                 logger.error("Error generando tabla bitácora detallada: %s", e_det)
                 log(f"Adv: Error generando tabla Bitácora Detallada: {e_det}")
-            df_daily_agg_full = _agregar_datos_diarios(df_combined, status_queue, selected_adsets)
 
-            if df_daily_agg_full is None or df_daily_agg_full.empty or 'date' not in df_daily_agg_full.columns or df_daily_agg_full['date'].dropna().empty:
-                log("!!! Falló agregación diaria o no hay fechas válidas. Abortando Bitácora. !!!", importante=True)
-                status_queue.put("---ERROR---"); return
-            log("Agregación diaria OK.")
-
-            log("--- Calculando Días Activos ---")
-            active_days_results = _calcular_dias_activos_totales(df_combined)
-            active_days_campaign = active_days_results.get('Campaign', pd.DataFrame())
-            active_days_adset = active_days_results.get('AdSet', pd.DataFrame())
-            active_days_ad = active_days_results.get('Anuncio', pd.DataFrame())
-            active_entities_daily = _calcular_entidades_activas_por_dia(df_combined)
-
-            df_daily_agg_full = _agregar_datos_diarios(df_combined, status_queue, selected_adsets)
-
-            if df_daily_agg_full is None or df_daily_agg_full.empty or 'date' not in df_daily_agg_full.columns or df_daily_agg_full['date'].dropna().empty:
-                log("!!! Falló agregación diaria o no hay fechas válidas. Abortando Bitácora. !!!", importante=True)
-                status_queue.put("---ERROR---"); return
-            log("Agregación diaria OK.")
-
-            log("--- Calculando Días Activos ---")
-            active_days_results = _calcular_dias_activos_totales(df_combined)
-            active_days_campaign = active_days_results.get('Campaign', pd.DataFrame())
-            active_days_adset = active_days_results.get('AdSet', pd.DataFrame())
-            active_days_ad = active_days_results.get('Anuncio', pd.DataFrame())
-            active_entities_daily = _calcular_entidades_activas_por_dia(df_combined)
-            try:
-                _generar_tabla_bitacora_detallada(df_daily_agg_full, detected_currency, log, active_entities_daily)
-            except Exception as e_det:
-                logger.error("Error generando tabla bitácora detallada: %s", e_det)
-                log(f"Adv: Error generando tabla Bitácora Detallada: {e_det}")
-
- main
 
             min_date_overall = df_daily_agg_full['date'].min().date()
             max_date_overall = df_daily_agg_full['date'].max().date()
@@ -572,62 +500,6 @@ c0tc8c-codex/extend-metric_calculators-for-active-days
             df_daily_total_for_bitacora['ctr_out'] = safe_division_pct(co_tot, i_tot)
             base_rv_tot=np.where(pd.Series(rv3_tot>0).fillna(False),rv3_tot,i_tot); df_daily_total_for_bitacora['rv25_pct']=safe_division_pct(rv25_tot,base_rv_tot); df_daily_total_for_bitacora['rv75_pct']=safe_division_pct(rv75_tot,base_rv_tot); df_daily_total_for_bitacora['rv100_pct']=safe_division_pct(rv100_tot,base_rv_tot)
 
- c0tc8c-codex/extend-metric_calculators-for-active-days
-            _generar_tabla_bitacora_entidad('Cuenta Completa', 'Agregado Total', df_daily_total_for_bitacora,
-                                            bitacora_periods_list, detected_currency, log, period_type=bitacora_comparison_type)
-
-            _generar_tabla_embudo_bitacora(df_daily_total_for_bitacora, bitacora_periods_list, log, detected_currency, period_type=bitacora_comparison_type)
-
-            try:
-                _generar_tabla_top_ads_historico(df_daily_agg_full, active_days_ad, log, detected_currency, top_n=15, sort_by_roas=True)
-            except Exception as e_top_ads:
-                log(f"Adv: Error generando Top Ads: {e_top_ads}")
-            try:
-                _generar_tabla_top_adsets_historico(df_daily_agg_full, active_days_adset, log, detected_currency, top_n=15)
-            except Exception as e_top_as:
-                log(f"Adv: Error generando Top AdSets: {e_top_as}")
-            try:
-                _generar_tabla_top_campaigns_historico(df_daily_agg_full, active_days_campaign, log, detected_currency, top_n=15)
-            except Exception as e_top_camp:
-                log(f"Adv: Error generando Top Campañas: {e_top_camp}")
-
-            log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
-            if log_summary_messages_orchestrator:
-                for msg in log_summary_messages_orchestrator:
-                    clean_msg = re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','', msg).strip().replace('---','-')
-                    log(f"  - {clean_msg}")
-            else:
-                log("  No se generaron mensajes de resumen.")
-
-            _generar_tabla_bitacora_entidad('Cuenta Completa', 'Agregado Total', df_daily_total_for_bitacora,
-                                            bitacora_periods_list, detected_currency, log, period_type=bitacora_comparison_type)
-
-            _generar_tabla_embudo_bitacora(df_daily_total_for_bitacora, bitacora_periods_list, log, detected_currency, period_type=bitacora_comparison_type)
-
-            try:
-                _generar_tabla_top_ads_historico(df_daily_agg_full, active_days_ad, log, detected_currency, top_n=15, sort_by_roas=True)
-            except Exception as e_top_ads:
-                log(f"Adv: Error generando Top Ads: {e_top_ads}")
-            try:
-                _generar_tabla_top_adsets_historico(df_daily_agg_full, active_days_adset, log, detected_currency, top_n=15)
-            except Exception as e_top_as:
-                log(f"Adv: Error generando Top AdSets: {e_top_as}")
-            try:
-                _generar_tabla_top_campaigns_historico(df_daily_agg_full, active_days_campaign, log, detected_currency, top_n=15)
-            except Exception as e_top_camp:
-                log(f"Adv: Error generando Top Campañas: {e_top_camp}")
-
-            log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
-            if log_summary_messages_orchestrator:
-                for msg in log_summary_messages_orchestrator:
-                    clean_msg = re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','', msg).strip().replace('---','-')
-                    log(f"  - {clean_msg}")
-            else:
-                log("  No se generaron mensajes de resumen.")
-
-            _generar_tabla_bitacora_entidad('Cuenta Completa', 'Agregado Total', df_daily_total_for_bitacora,
-                                            bitacora_periods_list, detected_currency, log, period_type=bitacora_comparison_type)
-
             _generar_tabla_embudo_bitacora(df_daily_total_for_bitacora, bitacora_periods_list, log, detected_currency, period_type=bitacora_comparison_type)
 
             try:
@@ -652,10 +524,6 @@ c0tc8c-codex/extend-metric_calculators-for-active-days
             else:
                 log("  No se generaron mensajes de resumen.")
 
-            log("\n\n============================================================");log(f"===== Resumen del Proceso (Bitácora {bitacora_comparison_type}) =====");log("============================================================")
-            if log_summary_messages_orchestrator: [log(f"  - {re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip().replace('---','-')}") for msg in log_summary_messages_orchestrator if re.sub(r'^\s*\[\d{2}:\d{2}:\d{2}\]\s*','',msg).strip()]
-            else: log("  No se generaron mensajes de resumen.")
- main
             log("============================================================")
             log(f"\n\n--- FIN DEL REPORTE BITÁCORA ({bitacora_comparison_type}) ---", importante=True); status_queue.put("---DONE---")
 


### PR DESCRIPTION
## Summary
- clean up import section and remove leftover markers
- keep one log summary block per function
- deduplicate daily aggregation logic for bitácora

## Testing
- `python -m py_compile data_processing/orchestrators.py`


------
https://chatgpt.com/codex/tasks/task_e_6848c79ed3cc8332a5fb8669f063cff6